### PR TITLE
Fix incorrectly named actually-all-emojis underscore package

### DIFF
--- a/espanso_package/actually-all-emojis/0.3.0/_manifest.yml
+++ b/espanso_package/actually-all-emojis/0.3.0/_manifest.yml
@@ -1,7 +1,7 @@
 author: Jobie Wong
 description: An updated package providing all v.15 emojis - fetched from unicode.org
-name: actually-all-emojis-spaces
-title: Actually All Emojis (Spaces)
+name: actually-all-emojis
+title: Actually All Emojis
 version: 0.3.0
 homepage: "https://github.com/jobiewong/espanso-emojis"
 tags: ["emoji", "chat"]


### PR DESCRIPTION
The v0.3.0 version of the underscore package mistakenly has the space package's name and title. That causes `actually-all-emojis` to show v0.1.0 as the latest version.